### PR TITLE
Redirect all links to licensing/about files to local copies on GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ function scrollToElement(element) {
     <br/>
     <h5 class="page_h5">Firefox XML-RPC Client (nsXmlRpcClient.js)</h5>
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/777a04b9c69d8b12cb35f2897c97446ed3ae084d/src/mozilla/nsXmlRpcClient.js">Source</a><br/>
-    <a id="custom_a" href="http://www.mozilla.org/MPL/MPL-1.1.html">Mozilla Public License 1.1</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/MPL1.1.txt">Mozilla Public License 1.1</a>
 
     <br/><br/>
     <h2 id="jira" class="page_h2">Atlassian Eclipse JIRA Connector EPL Code</h2>
@@ -92,7 +92,7 @@ function scrollToElement(element) {
     </h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/777a04b9c69d8b12cb35f2897c97446ed3ae084d/src/jira/com.atlassian.connector-3.0.6.11.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h4 class="page_h4">com.atlassian.connector 3.0.6.15</h4>
 
@@ -101,7 +101,7 @@ function scrollToElement(element) {
     </h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/777a04b9c69d8b12cb35f2897c97446ed3ae084d/src/jira/com.atlassian.connector-3.0.6.15.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h4 class="page_h4">com.atlassian.connector 3.0.6.16</h4>
 
@@ -110,7 +110,7 @@ function scrollToElement(element) {
     </h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/777a04b9c69d8b12cb35f2897c97446ed3ae084d/src/jira/com.atlassian.connector-3.0.6.16.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h4 class="page_h4">com.atlassian.connector 3.0.6.17</h4>
 
@@ -119,7 +119,7 @@ function scrollToElement(element) {
     </h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/jira/com.atlassian.connector-3.0.6.17.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h4 class="page_h4">com.atlassian.connector 3.0.6.18</h4>
 
@@ -128,7 +128,7 @@ function scrollToElement(element) {
     </h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/jira/com.atlassian.connector-3.0.6.18.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <br/><br/>
 
@@ -138,120 +138,120 @@ function scrollToElement(element) {
     <h5 class="page_h5">org.eclipse.birt.chart.device.swt(2.3.1.v20080731)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.birt.chart.device.swt_2.3.1.v20080731.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.birt.chart.device.swt/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.birt.chart.device.swt.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.birt.chart.device.swt (2.2.2.r222_v20071023)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.birt.chart.device.swt_2.2.2.r222_v20071023.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.birt.chart.device.swt/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.birt.chart.device.swt.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.core.resources.win32 (3.3.0v.20070226)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.core.resources.win32_3.3.0.v20070226.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.core.resources.win32/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.core.resources.win32.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.core.resources (3.7.100.v20110510-0712)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/777a04b9c69d8b12cb35f2897c97446ed3ae084d/src/eclipse/org.eclipse.core.resources_3.7.100.v20110510-0712.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.core.resources/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.core.resources.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.core.resources (3.6.0.v20100526-0737)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/777a04b9c69d8b12cb35f2897c97446ed3ae084d/src/eclipse/org.eclipse.core.resources_3.6.0.v20100526-0737.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.core.resources/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.core.resources.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.core.resources (3.5.2.R35x_v20091203-1236)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/777a04b9c69d8b12cb35f2897c97446ed3ae084d/src/eclipse/org.eclipse.core.resources_3.5.2.R35x_v20091203-1236.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.core.resources/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.core.resources.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.core.resources (3.4.1.R34x_v20080902)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.core.resources_3.4.1.R34x_v20080902.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.core.resources/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.core.resources.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.core.resources (3.4.0.v20071210)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.core.resources_3.4.0.v20071210.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.core.resources/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.core.resources.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.epf.common (1.2.0.v20100310)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.epf.common_1.2.0.v20100310.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.epf.common/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.epf.common.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.epf.richtext (1.2.0.v20100310)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.epf.richtext_1.2.0.v20100310.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.epf.richtext/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.epf.richtext.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.epf.ui (1.2.0.v20100310)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.epf.ui_1.2.0.v20100310.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.epf.ui/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.epf.ui.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.swt.carbon.macosx (3.4.1.v3449c)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.swt.carbon.macosx_3.4.1.v3449c.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.swt.carbon.macosx/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a><br>
-    <a id="custom_a" href="http://tasktop.devcloud.acquia-sites.com/legal/patches/org.eclipse.swt.carbon.macosx/about_files/IJG_README">The Independent JPEG Group's JPEG software</a><br>
-    <a id="custom_a" href="http://tasktop.devcloud.acquia-sites.com/legal/patches/org.eclipse.swt.carbon.macosx/about_files/mpl-v11.txt">Mozilla Public License 1.1</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.swt.carbon.macosx.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/IJG_README.txt">The Independent JPEG Group's JPEG software</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/MPL1.1.txt">Mozilla Public License 1.1</a>
 
     <h5 class="page_h5">org.eclipse.swt.win32.win32.x86 (3.3.0v.3346)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.swt.win32.win32.x86_3.3.0.v3346.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.swt.win32.win32.x86/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a><br>
-    <a id="custom_a" href="http://tasktop.devcloud.acquia-sites.com/legal/patches/org.eclipse.swt.carbon.macosx/about_files/IJG_README">The Independent JPEG Group's JPEG software</a><br>
-    <a id="custom_a" href="http://tasktop.devcloud.acquia-sites.com/legal/patches/org.eclipse.swt.carbon.macosx/about_files/mpl-v11.txt">Mozilla Public License 1.1</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.swt.win32.win32.x86.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/IJG_README.txt">The Independent JPEG Group's JPEG software</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/MPL1.1.txt">Mozilla Public License 1.1</a>
 
     <h5 class="page_h5">org.eclipse.ui.ide (3.7.0.I20110519-0100)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.ui.ide_3.7.0.I20110519-0100.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.ui.ide/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.ui.ide.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.ui.ide (3.6.0.I20100601-0800)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.ui.ide_3.6.0.I20100601-0800.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.ui.ide/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.ui.ide.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.ui.ide (3.5.2.M20100113-0800)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.ui.ide_3.5.2.M20100113-0800.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.ui.ide/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.ui.ide.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.ui.ide (3.4.1.M20080903-2000)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.ui.ide_3.4.1.M20080903-2000.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.ui.ide/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.ui.ide.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.ui.ide (3.3.2.M20080207-0800)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.ui.ide_3.3.2.M20080207-0800.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.ui.ide/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.ui.ide.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">org.eclipse.ui.ide (3.3.1M20070910-0800b)</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/eclipse/org.eclipse.ui.ide_3.3.1.M20070910-0800b.zip">Modified Source</a><br>
-    <a id="custom_a" href="https://my.tasktop.com/legal/patches/org.eclipse.ui.ide/about.html">About</a><br>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/org.eclipse.ui.ide.txt">About</a><br>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <br/><br/>
 
@@ -261,62 +261,62 @@ function scrollToElement(element) {
     <h5 class="page_h5">Tasktop Base Application</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/777a04b9c69d8b12cb35f2897c97446ed3ae084d/src/epl/com.tasktop.base.application.ui_1.1.2.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">Tasktop EPL Commons</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/777a04b9c69d8b12cb35f2897c97446ed3ae084d/src/epl/com.tasktop.epl.commons.core_3.0.0.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">Eclipse EPF</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/777a04b9c69d8b12cb35f2897c97446ed3ae084d/src/epl/com.tasktop.org.eclipse.epf_1.2.5.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">Mylyn - FillWidthLayout</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/epl/FillWidthLayout.java">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">Mylyn - HTTP Commons</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/epl/com.tasktop.mylyn.commons.http.core_1.0.3.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">Mylyn - HtmlStreamTokenizer</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/epl/HtmlStreamTokenizer_m3_8.java">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">Mylyn - HtmlTag</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/epl/HtmlTag_m3_8.java">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">Mylyn - OSLC</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/epl/com.tasktop.mylyn.oslc_3.11.0.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">Mylyn - SOAP Commons</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/epl/com.tasktop.mylyn.commons.soap_3.11.0.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">Mylyn - TaskEditorPeoplePart</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/epl/MingleTaskEditorPeoplePart.java">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">Mylyn - TaskDataDiff</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/epl/SyncTaskDataDiff.zip">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
 
     <h5 class="page_h5">Mylyn - TaskAttributeDiff</h5>
 
     <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/aed7ab7108e18059fd5d5bec8beb08cb22f1b37e/src/epl/SyncTaskAttributeDiff.java">Source</a><br/>
-    <a id="custom_a" href="http://www.eclipse.org/legal/epl-v10.html">Eclipse Public License 1.0</a>
+    <a id="custom_a" href="https://github.com/Tasktop/code.modifications/raw/0ea665a3ee32a6557037fd4943b5b936c97d10f7/src/about/epl-v10.txt">Eclipse Public License 1.0</a>
   </section>
 </div>
 


### PR DESCRIPTION
- remove all references to webhosts
- redirects all point to raw resources using commit hash permalink
